### PR TITLE
Add Max Context Len value to get around with context len 1 error

### DIFF
--- a/docs/portal/dist/db.json
+++ b/docs/portal/dist/db.json
@@ -64,14 +64,15 @@
     "name": "dustynv/vllm:0.7.4-r36.4.0-cu128-24.04",
     "docker_image": "dustynv/vllm:0.7.4-r36.4.0-cu128-24.04",
     "docker_cmd": "vllm serve ${MODEL}",
-    "docker_args": "--host=${SERVER_ADDR} --port=${SERVER_PORT} --dtype=auto --max-num-seqs=${MAX_BATCH_SIZE} --max-model-len=${MAX_CONTEXT_LEN} --gpu-memory-utilization=0.75",
+    "docker_args": "--host=${SERVER_ADDR} --port=${SERVER_PORT} --dtype=auto --max-num-seqs=${MAX_BATCH_SIZE} --max-model-len=${MAX_CONTEXT_LEN} --gpu-memory-utilization=0.757",
     "docker_options": "-it --rm",
     "server_host": "0.0.0.0:9000",
     "tags": [
       "container",
       "vllm",
       "l4t-r36"
-    ]
+    ],
+    "max_context_len": 8192
   },
   "sudonim": {
     "docker_cmd": "sudonim serve",

--- a/docs/portal/dist/db.json
+++ b/docs/portal/dist/db.json
@@ -64,7 +64,7 @@
     "name": "dustynv/vllm:0.7.4-r36.4.0-cu128-24.04",
     "docker_image": "dustynv/vllm:0.7.4-r36.4.0-cu128-24.04",
     "docker_cmd": "vllm serve ${MODEL}",
-    "docker_args": "--host=${SERVER_ADDR} --port=${SERVER_PORT} --dtype=auto --max-num-seqs=${MAX_BATCH_SIZE} --max-model-len=${MAX_CONTEXT_LEN} --gpu-memory-utilization=0.757",
+    "docker_args": "--host=${SERVER_ADDR} --port=${SERVER_PORT} --dtype=auto --max-num-seqs=${MAX_BATCH_SIZE} --max-model-len=${MAX_CONTEXT_LEN} --gpu-memory-utilization=0.75",
     "docker_options": "-it --rm",
     "server_host": "0.0.0.0:9000",
     "tags": [
@@ -72,7 +72,8 @@
       "vllm",
       "l4t-r36"
     ],
-    "max_context_len": 8192
+    "max_context_len": 8192,
+    "hf_token": "${HUGGINGFACE_TOKEN}"
   },
   "sudonim": {
     "docker_cmd": "sudonim serve",


### PR DESCRIPTION
Originally, `--max-model-len=1` was set and it was causing the "context length 1" error.

> "This model's maximum context length is 1 tokens. However, you requested 28 tokens in the messages, Please reduce the length of the messages."

This work around will generate the command like below, instead of  `--max-model-len=1`.

Verified with JAO 64GB & JAO 32GB (`gemma-3-4b-it`), Orin NX 16GB (`gemma-3-1b-it`) with `vlm.py`.

```
docker run -it --rm \
  --name llm_server \
  --gpus all \
  -p 9000:9000 \
  -e DOCKER_PULL=always --pull always \
  -e HF_TOKEN=${HUGGINGFACE_TOKEN} \
  -e HF_HUB_CACHE=/root/.cache/huggingface \
  -v /mnt/nvme/cache:/root/.cache \
  dustynv/vllm:0.7.4-r36.4.0-cu128-24.04 \
  vllm serve google/gemma-3-4b-it \
  --host=0.0.0.0 --port=9000 --dtype=auto --max-num-seqs=1 --max-model-len=8192 --gpu-memory-utilization=0.75
```