### PR TITLE
Remove `s` leftover from models.html

### DIFF
--- a/docs/overrides/models.html
+++ b/docs/overrides/models.html
@@ -31,7 +31,7 @@
   
 {% endblock %}
 {% block tabs %}
-{{ super() }}s
+{{ super() }}
 {% endblock %}
 {% block content %}
 


### PR DESCRIPTION
I was browsing the site and discovered that on models pages there is a floating `s` letter. This change removes it.