### PR TITLE
Fix to enable ci build

### DIFF
--- a/scripts/duplicate_site_with_postprocess.py
+++ b/scripts/duplicate_site_with_postprocess.py
@@ -17,6 +17,10 @@ def duplicate_and_process_html(src_dir, dest_dir):
 
     # Walk through the source directory
     for root, dirs, files in os.walk(src_dir):
+
+        if 'dist' in dirs:
+            dirs.remove('dist')
+
         # Create corresponding directory in the destination
         rel_path = os.path.relpath(root, src_dir)
         dest_subdir = os.path.join(dest_dir, rel_path)
@@ -30,6 +34,7 @@ def duplicate_and_process_html(src_dir, dest_dir):
             if file_name.endswith(".html"):
                 # ### HTML file ### 
                 #  - Make certain nav items collapse by removing `md-toggle--indeterminate` class.
+                print(f"--> Processing file: {src_file_path}")
                 postprocess_html_file(src_file_path, dest_file_path)
             else:
                 # Copy non-HTML files as-is


### PR DESCRIPTION
The page wasn't updated because of failing CI.

The postprocess py code is also crawling dist folders? -> Probably wasn't intention. @tokk-nv 

