### PR TITLE
Update pip install command for aiohttp module

### DIFF
--- a/docs/vit/tutorial_nanoowl.md
+++ b/docs/vit/tutorial_nanoowl.md
@@ -51,7 +51,7 @@ jetson-containers run --workdir /opt/nanoowl $(autotag nanoowl)
 1. Install missing module.
 
     ```bash
-    pip install aiohttp
+    pip install aiohttp --index-url=https://pypi.jetson-ai-lab.io/jp6/cu126
     ```
 
 2. Launch the demo


### PR DESCRIPTION
Patching the pip install error due to missing --index-url=https://pypi.jetson-ai-lab.io/jp6/cu126 in the container image.