### PR TITLE
fix: Remove NVIDIA org affiliation from Dustin Franklin's profile

### DIFF
--- a/src/content/pages/research.md
+++ b/src/content/pages/research.md
@@ -60,7 +60,7 @@ past_meetings:
 team_members:
   - name: "Dustin Franklin"
     role: "Principal Engineer"
-    org: "NVIDIA"
+    org: ""
     location: "Pittsburgh, PA"
     image: "/images/research/Dustin_Franklin.jpg"
     linkedin: "https://www.linkedin.com/in/dustin-franklin-b3aaa173/"


### PR DESCRIPTION
- Update research.md to remove org field for Dustin Franklin
- Reflects current affiliation status