### PR TITLE
fix: Add _satellite undefined check to prevent console error

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -681,6 +681,11 @@ const { title, description = "Experience the latest generative AI models optimiz
         s.parentNode.insertBefore(gd, s);
       })();
     </script>
-    <script is:inline type="text/javascript">_satellite.pageBottom();</script>
+    <script is:inline type="text/javascript">
+      // Only call _satellite if Adobe DTM is loaded (production only)
+      if (typeof _satellite !== 'undefined') {
+        _satellite.pageBottom();
+      }
+    </script>
   </body>
 </html>


### PR DESCRIPTION
- Wrap _satellite.pageBottom() call in typeof check
- Prevents 'ReferenceError: _satellite is not defined' on localhost
- Adobe DTM script only loads on production domain, so _satellite is undefined locally
- Error was appearing in browser console during development

### Screenshot of the error
<img width="2700" height="962" alt="2025-12-17_22h39_14" src="https://github.com/user-attachments/assets/e561974e-cd9a-45e9-9cd8-fc03f6a06293" />
