### PR TITLE
fix: Improve hero image sizing on mobile devices

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -42,8 +42,8 @@ const sourceColors: Record<string, { bg: string; text: string }> = {
           </a>
         </div>
       </div>
-      <div class="flex-1 flex justify-center lg:justify-end">
-        <img src="/images/hero/jetson-family-line_50pcnt.png" alt="NVIDIA Jetson AI Illustration" class="max-w-[192px] md:max-w-[640px] w-auto h-auto" />
+      <div class="flex-1 flex justify-center lg:justify-end w-full">
+        <img src="/images/hero/jetson-family-line_50pcnt.png" alt="NVIDIA Jetson AI Illustration" class="w-full md:max-w-md lg:max-w-xl h-auto" />
       </div>
     </div>
   </section>


### PR DESCRIPTION
- Change from tiny 192px max-width to full-width on mobile
- Image now takes up entire screen width below text on mobile devices
- Properly scaled on medium (448px max-w-md) and large (576px max-w-xl) screens
- Hero image was previously dramatically shrunk on viewports < 768px
- Much more impactful and visually appealing on mobile phones

### Screenshot of the issue
<img width="1485" height="1382" alt="2025-12-17_22h37_45" src="https://github.com/user-attachments/assets/97a60056-0854-4b0b-a60d-7f78d32c3cf9" />
