### PR TITLE
feat: Add 5 new community projects from 2025

### DIFF
--- a/src/content/projects/curious-frame-ai-tutor.md
+++ b/src/content/projects/curious-frame-ai-tutor.md
@@ -1,0 +1,33 @@
+---
+title: "The Curious Frame: An Offline AI Tutor for Kids"
+description: "A screen-free educational device using Jetson Orin Nano with VLM and LLM to identify objects and explain them to kids in their language through voice."
+author: "Frederic Collonval"
+date: "2025-08-19"
+source: "Hackster"
+image: "https://hackster.imgix.net/uploads/attachments/1872832/_z3jxuwvChS.blob?auto=compress%2Cformat&w=900&h=675&fit=min"
+link: "https://www.hackster.io/frederic-collonval/the-curious-frame-an-offline-ai-tutor-for-kids-686677"
+featured: true
+tags: ["education", "kids", "vlm", "llm", "moondream", "gemma", "tts", "ollama", "orin-nano", "screen-free"]
+---
+
+Frederic Collonval created a screen-free AI tutor for children that uses a handheld cardboard frame to identify everyday objects and explain them through voice in multiple languages, all running locally on Jetson Orin Nano.
+
+The system uses moondream2 VLM for object detection, Gemma 3n LLM via Ollama for generating age-appropriate explanations, and Piper TTS for voice output. A clever flag-based interface allows children to switch between languages, turning it into both an educational tool and a language-learning device.
+
+### Features
+
+- Screen-free interaction for healthy child development
+- moondream2 vision-language model for object detection
+- Gemma 3n LLM for child-safe, age-appropriate explanations
+- Piper TTS for natural voice narration
+- Multilingual support with visual language switching
+- Fully offline operation on Jetson Orin Nano 8GB
+- Simple cardboard frame interface requiring no complex input
+- Automated setup script for easy deployment
+
+### Resources
+
+- [Hackster Project](https://www.hackster.io/frederic-collonval/the-curious-frame-an-offline-ai-tutor-for-kids-686677)
+- [GitHub Repository](https://github.com/webscit/curious-frame)
+
+

--- a/src/content/projects/gps-denied-drone-vslam.md
+++ b/src/content/projects/gps-denied-drone-vslam.md
@@ -1,0 +1,33 @@
+---
+title: "GPS-Denied Drone with NVIDIA Jetson Orin Nano"
+description: "Autonomous drone using real-time VSLAM on Jetson Orin Nano with Isaac ROS to navigate GPS-denied environments via visual-inertial odometry and onboard mapping."
+author: "Andrew Bernas"
+date: "2025-06-22"
+source: "Hackster"
+image: "https://hackster.imgix.net/uploads/attachments/1860199/_3us6r87BE8.blob?auto=compress%2Cformat&w=900&h=675&fit=min"
+link: "https://www.hackster.io/bandofpv/gps-denied-drone-with-nvidia-jetson-orin-nano-9f3417"
+featured: true
+tags: ["vslam", "isaac-ros", "drone", "autonomous", "px4", "mavros", "robotics", "orin-nano"]
+---
+
+Andrew Bernas developed an autonomous UAV platform powered by Visual Simultaneous Localization and Mapping (VSLAM) using Isaac ROS, integrated with MAVROS and PX4 flight stack. The system enables real-time localization and mapping for autonomous navigation in GPS-denied environments.
+
+By fusing visual-inertial data from an Intel D435i camera and leveraging Jetson Orin Nano's edge computing capabilities, the drone can maintain situational awareness, dynamically map unknown environments, and execute autonomous flight patterns with high precision—all without GPS dependency.
+
+### Features
+
+- Isaac ROS VSLAM for real-time visual-inertial odometry
+- PX4 flight controller integration via MAVROS
+- Intel RealSense D435i stereo camera with IMU
+- Extended Kalman Filter (EKF) for sensor fusion
+- Autonomous flight pattern execution (square, circle, figure-8, spiral)
+- Real-time mapping and localization on edge device
+- Complete ROS2 integration for visualization and control
+- Fully autonomous operation in GPS-denied scenarios
+
+### Resources
+
+- [Hackster Project](https://www.hackster.io/bandofpv/gps-denied-drone-with-nvidia-jetson-orin-nano-9f3417)
+- [GitHub Repository](https://github.com/bandofpv/VSLAM-UAV)
+
+

--- a/src/content/projects/gpt-oss-storyteller.md
+++ b/src/content/projects/gpt-oss-storyteller.md
@@ -1,0 +1,32 @@
+---
+title: "GPT-OSS-20B Interactive Storyteller"
+description: "An interactive storytelling system for children using Jetson AGX Orin with LLM, image generation, TTS, and voice control for creating dynamic stories with visuals and sound."
+author: "Timothy Lovett"
+date: "2025-09-23"
+source: "Hackster"
+link: "https://www.hackster.io/timo614/gpt-oss-20b-storyteller-c91042"
+image: "https://hackster.imgix.net/uploads/attachments/1889223/_IGMA29ZuBT.blob?auto=compress%2Cformat&w=900&h=675&fit=min"
+featured: true
+tags: ["llm", "storytelling", "comfyui", "sdxl", "tts", "asr", "whisper", "ollama", "agx-orin"]
+---
+
+Timothy Lovett created an interactive storytelling system for children that combines multiple AI models on Jetson AGX Orin to generate dynamic stories with accompanying visuals, voice narration, and adaptive sound effects.
+
+The system uses voice input from children to shape story direction, generates illustrations on-the-fly with ComfyUI and SDXL, narrates with Piper TTS, and controls mood-based background music through a Seeed MIDI Synthesizer. All processing runs locally on the edge without cloud connectivity.
+
+### Features
+
+- GPT-OSS-20B LLM via Ollama for story generation
+- ComfyUI + SDXL with HyperSD LoRA for real-time image generation
+- Faster Whisper for voice-to-text transcription
+- Piper TTS for natural voice narration
+- Seeed MIDI Synthesizer for interactive control and mood-based audio
+- Projector display for immersive storytelling experience
+- Fully local processing on Jetson AGX Orin
+
+### Resources
+
+- [Hackster Project](https://www.hackster.io/timo614/gpt-oss-20b-storyteller-c91042)
+- [GitHub Repository](https://github.com/Timo614/gpt-oss-storyteller)
+
+

--- a/src/content/projects/n8n-rag-agent.md
+++ b/src/content/projects/n8n-rag-agent.md
@@ -1,0 +1,31 @@
+---
+title: "Build Local AI RAG Agent with n8n on NVIDIA Jetson AGX Orin"
+description: "A fully local Retrieval-Augmented Generation (RAG) AI agent running on Jetson AGX Orin using n8n workflow automation, Qwen3-4B LLM, and Telegram integration."
+author: "Nurgaliyev Shakhizat"
+date: "2024-08-12"
+source: "Hackster"
+link: "https://www.hackster.io/shahizat/build-local-ai-rag-agent-with-n8n-on-nvidia-jetson-agx-orin-665914"
+image: "https://hackster.imgix.net/uploads/attachments/1872883/_kR3My3eE2X.blob?auto=compress%2Cformat&w=900&h=675&fit=min"
+featured: true
+tags: ["rag", "llm", "n8n", "workflow-automation", "qwen", "telegram", "agx-orin"]
+---
+
+Nurgaliyev Shakhizat demonstrates how to build a fully local Retrieval-Augmented Generation (RAG) AI agent on the NVIDIA Jetson AGX Orin Developer Kit using n8n workflow automation platform.
+
+The system integrates multiple components including Qwen3-4B LLM served via SGLang, Snowflake-Arctic-Embed2 for text embeddings through Ollama, Qdrant vector database for semantic search, and Telegram for real-time messaging interface. WireGuard VPN provides secure remote access without exposing services publicly.
+
+### Features
+
+- Fully offline RAG pipeline on edge device
+- n8n workflow automation for orchestration
+- Qwen3-4B LLM with SGLang for low-latency inference
+- Qdrant vector database for semantic retrieval
+- Telegram bot interface for natural interaction
+- Secure remote access via WireGuard VPN
+
+### Resources
+
+- [Hackster Project](https://www.hackster.io/shahizat/build-local-ai-rag-agent-with-n8n-on-nvidia-jetson-agx-orin-665914)
+- [NVIDIA Forums Discussion](https://forums.developer.nvidia.com/t/build-local-ai-rag-agent-with-n8n-on-nvidia-jetson-agx-orin/342095)
+
+

--- a/src/content/projects/reflective-diffusion-mirror.md
+++ b/src/content/projects/reflective-diffusion-mirror.md
@@ -1,0 +1,33 @@
+---
+title: "Reflective Diffusion: AI Magic Mirror"
+description: "An interactive magic mirror using Jetson AGX Orin with SDXL diffusion to render artistic images from voice prompts and camera captures."
+author: "Timothy Lovett & Kerin Lovett"
+date: "2025-08-15"
+source: "Hackster"
+image: "https://hackster.imgix.net/uploads/attachments/1875147/_37gyfNJtG3.blob?auto=compress%2Cformat&w=900&h=675&fit=min"
+link: "https://www.hackster.io/irelas/reflective-diffusion-0824ae"
+featured: true
+tags: ["sdxl", "diffusion", "comfyui", "whisper", "image-generation", "mirror", "esp32", "agx-orin"]
+---
+
+Timothy and Kerin Lovett created an interactive magic mirror that combines a wall-mounted display with real-time SDXL image generation. The system captures photos and voice prompts via ESP32S3, processes them through ComfyUI on Jetson AGX Orin, and renders artistic transformations on a mirror-enclosed screen.
+
+The magic mirror uses mirror acrylic that appears as a normal mirror when off but displays generated images when active. Voice prompts are transcribed with Whisper, combined with camera captures, and processed through SDXL with ControlNet++ and Depth Anything V2 for coherent artistic renderings.
+
+### Features
+
+- Real-time SDXL image generation with ComfyUI
+- Voice-activated prompting using Whisper for transcription
+- ESP32S3 Sense for wireless camera and audio capture
+- ControlNet++ with Depth Anything V2 for depth-aware generation
+- HyperSD LoRA for fast 2-step diffusion
+- Mirror acrylic display in shadow box frame
+- WebSocket-based image streaming
+- Fully local processing on Jetson AGX Orin
+
+### Resources
+
+- [Hackster Project](https://www.hackster.io/irelas/reflective-diffusion-0824ae)
+- [GitHub Repository](https://github.com/Timo614/reflective-diffusion)
+
+

--- a/src/pages/community.astro
+++ b/src/pages/community.astro
@@ -25,7 +25,7 @@ const sourceColors: Record<string, { bg: string; text: string }> = {
       <div class="absolute -top-40 -right-40 w-96 h-96 bg-nvidia-green/20 rounded-full blur-3xl"></div>
       <div class="absolute top-20 -left-20 w-72 h-72 bg-purple-500/10 rounded-full blur-3xl"></div>
     </div>
-    
+
     <div class="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
       <h1 class="text-5xl md:text-6xl font-bold tracking-tight mb-6">
         <span class="bg-clip-text text-transparent bg-gradient-to-r from-nvidia-white to-nvidia-gray-300">
@@ -35,12 +35,12 @@ const sourceColors: Record<string, { bg: string; text: string }> = {
       <p class="text-xl text-nvidia-gray-300 max-w-2xl mx-auto leading-relaxed">
         Discover guides, tutorials, and articles contributed by the community showcasing generative AI on the Jetson platform.
       </p>
-      
+
       <div class="mt-10 flex flex-wrap justify-center gap-4">
         <a href="https://discord.gg/nvidia-jetson" target="_blank" rel="noopener" class="px-6 py-3 bg-nvidia-green text-nvidia-black font-bold rounded-lg hover:bg-nvidia-green/90 transition-all">
           Join Discord
         </a>
-        <a href="https://github.com/dusty-nv/jetson-containers" target="_blank" rel="noopener" class="px-6 py-3 bg-white/10 backdrop-blur-sm text-white font-semibold rounded-lg hover:bg-white/20 transition-all border border-white/10">
+        <a href="https://github.com/nvidia-ai-iot/jetson-ai-lab" target="_blank" rel="noopener" class="px-6 py-3 bg-white/10 backdrop-blur-sm text-white font-semibold rounded-lg hover:bg-white/20 transition-all border border-white/10">
           Contribute on GitHub
         </a>
       </div>
@@ -58,7 +58,7 @@ const sourceColors: Record<string, { bg: string; text: string }> = {
               {/* Media */}
               <div class="relative aspect-video bg-nvidia-gray-100 overflow-hidden">
                 {project.data.video ? (
-                  <iframe 
+                  <iframe
                     src={project.data.video}
                     class="w-full h-full"
                     frameborder="0"
@@ -66,8 +66,8 @@ const sourceColors: Record<string, { bg: string; text: string }> = {
                     allowfullscreen
                   ></iframe>
                 ) : project.data.image ? (
-                  <img 
-                    src={project.data.image} 
+                  <img
+                    src={project.data.image}
                     alt={project.data.title}
                     class="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
                   />
@@ -78,13 +78,13 @@ const sourceColors: Record<string, { bg: string; text: string }> = {
                     </svg>
                   </div>
                 )}
-                
+
                 {/* Source Badge */}
                 <span class={`absolute top-3 left-3 px-2 py-1 text-xs font-bold rounded ${colors.bg} ${colors.text}`}>
                   {project.data.source}
                 </span>
               </div>
-              
+
               {/* Content */}
               <div class="p-5">
                 <div class="flex items-center justify-between mb-2">
@@ -93,15 +93,15 @@ const sourceColors: Record<string, { bg: string; text: string }> = {
                     {new Date(project.data.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}
                   </span>
                 </div>
-                
+
                 <h3 class="text-lg font-bold text-nvidia-black mb-2 group-hover:text-nvidia-green transition-colors line-clamp-2">
                   {project.data.title}
                 </h3>
-                
+
                 <p class="text-nvidia-gray-600 text-sm line-clamp-3">
                   {project.data.description}
                 </p>
-                
+
                 {project.data.tags && (
                   <div class="flex flex-wrap gap-1.5 mt-4">
                     {project.data.tags.slice(0, 3).map((tag: string) => (


### PR DESCRIPTION
- GPS-Denied Drone with VSLAM (June 2025)
- Reflective Diffusion Magic Mirror (Aug 2025)
- Curious Frame AI Tutor for Kids (Aug 2025)
- GPT-OSS-20B Interactive Storyteller (Sept 2025)
- n8n RAG Agent (Aug 2024)

All projects showcase generative AI and robotics on Jetson. Updated GitHub link to point to jetson-ai-lab repo.