### PR TITLE
Pin the VLLM container tag for Thor to 0.14.0

### DIFF
--- a/src/content/models/cosmos-reason2-2b.md
+++ b/src/content/models/cosmos-reason2-2b.md
@@ -65,7 +65,7 @@ You will need an [NGC account](https://ngc.nvidia.com/) with access to the `nim`
 ```bash
 ngc registry model download-version "nim/nvidia/cosmos-reason2-2b:1208-fp8-static-kv8" \
   --dest ~/.cache/huggingface/hub
-MODEL_PATH="$(home)/.cache/huggingface/hub"
+MODEL_PATH="$(home)/.cache/huggingface/hub/cosmos-reason2-2b_v1208-fp8-static-kv8"
 ```
 
 ### Step 3: Serve
@@ -84,8 +84,8 @@ sudo sysctl -w vm.drop_caches=3
 sudo docker run -it --rm --runtime=nvidia --network host \
   -v $MODEL_PATH:/models/cosmos-reason2-2b:ro \
   ghcr.io/nvidia-ai-iot/vllm:0.14.0-r38.3-arm64-sbsa-cu130-24.04 \
-  vllm serve /models/cosmos-reason2-8b \
-    --model nvidia/cosmos-reason2-2b-fp8 \
+  vllm serve /models/cosmos-reason2-2b \
+    --served-model-name nvidia/cosmos-reason2-8b-fp8 \
     --max-model-len 8192 \
     --gpu-memory-utilization 0.8 \
     --reasoning-parser qwen3 \

--- a/src/content/models/cosmos-reason2-8b.md
+++ b/src/content/models/cosmos-reason2-8b.md
@@ -57,7 +57,7 @@ You will need an [NGC account](https://ngc.nvidia.com/) with access to the `nim`
 ```bash
 ngc registry model download-version "nim/nvidia/cosmos-reason2-8b:1208-fp8-static-kv8" \
   --dest ~/.cache/huggingface/hub
-MODEL_PATH="$(home)/.cache/huggingface/hub"
+export MODEL_PATH="${HOME}/.cache/huggingface/hub/cosmos-reason2-8b_v1208-fp8-static-kv8"
 ```
 
 ### Step 3: Serve
@@ -76,7 +76,7 @@ sudo docker run -it --rm --runtime=nvidia --network host \
   -v $MODEL_PATH:/models/cosmos-reason2-8b:ro \
   ghcr.io/nvidia-ai-iot/vllm:0.14.0-r38.3-arm64-sbsa-cu130-24.04 \
   vllm serve /models/cosmos-reason2-8b \
-    --model nvidia/cosmos-reason2-8b-fp8 \
+    --served-model-name nvidia/cosmos-reason2-8b-fp8 \
     --max-model-len 8192 \
     --gpu-memory-utilization 0.8 \
     --reasoning-parser qwen3 \


### PR DESCRIPTION
This fix is to pin the VLLM container tag to 0.14.0, to run cosmos-reason2 on Thor.

`ghcr.io/nvidia-ai-iot/vllm:latest-jetson-thor` currently points to [`0.16.0-g15d76f74e-r38.2-arm64-sbsa-cu130-24.04`](https://github.com/orgs/NVIDIA-AI-IOT/packages/container/vllm/709883739?tag=0.16.0-g15d76f74e-r38.2-arm64-sbsa-cu130-24.04) which is known to produce garbage when serving CR2 models.

**Changed to:**

```bash
sudo sysctl -w vm.drop_caches=3

sudo docker run -it --rm --runtime=nvidia --network host \
  -v $MODEL_PATH:/models/cosmos-reason2-8b:ro \
  ghcr.io/nvidia-ai-iot/vllm:0.14.0-r38.3-arm64-sbsa-cu130-24.04 \
  vllm serve /models/cosmos-reason2-8b \
    --served-model-name nvidia/cosmos-reason2-8b-fp8 \
    --max-model-len 8192 \
    --gpu-memory-utilization 0.8 \
    --reasoning-parser qwen3 \
    --media-io-kwargs '{"video": {"num_frames": -1}}' \
    --enable-prefix-caching \
    --port 8000
```