### PR TITLE
Add anchor for Performance Comparison section (#performance-comparison)

### DIFF
--- a/src/pages/models/index.astro
+++ b/src/pages/models/index.astro
@@ -163,7 +163,7 @@ const families = Array.from(new Set(models.map(m => m.family)))
   </section>
 
   <!-- Benchmarks Section -->
-  <section class="py-20 bg-nvidia-gray-50">
+  <section id="performance-comparison" class="py-20 bg-nvidia-gray-50">
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
       <div class="text-center mb-16">
         <h2 class="text-4xl font-bold text-nvidia-black mb-6">Performance Comparison</h2>


### PR DESCRIPTION
Will enable https://www.jetson-ai-lab.com/models/#performance-comparison

<img width="1280" height="1052" alt="image" src="https://github.com/user-attachments/assets/6e0408ac-c4f0-4197-b3ff-41d0062986a8" />