### PR TITLE
feat(models): Gemma 4 serving front matter with per-module support

### DIFF
--- a/src/content/models/gemma4-26b-a4b.md
+++ b/src/content/models/gemma4-26b-a4b.md
@@ -14,11 +14,26 @@ model_size: "16.8GB"
 hf_checkpoint: "ggml-org/gemma-4-26B-A4B-it-GGUF"
 huggingface_url: "https://huggingface.co/google/gemma-4-26B-A4B-it"
 minimum_jetson: "AGX Orin"
-supported_inference_engines:
-  - engine: "llama.cpp"
-    type: "Container"
-    run_command_orin: "sudo docker run -it --rm --pull always --runtime=nvidia --network host -v $HOME/.cache/huggingface:/root/.cache/huggingface ghcr.io/nvidia-ai-iot/llama_cpp:gemma4-jetson-orin llama-server -hf ggml-org/gemma-4-26B-A4B-it-GGUF:Q4_K_M"
-    run_command_thor: "sudo docker run -it --rm --pull always --runtime=nvidia --network host -v $HOME/.cache/huggingface:/root/.cache/huggingface ghcr.io/nvidia-ai-iot/llama_cpp:gemma4-jetson-thor llama-server -hf ggml-org/gemma-4-26B-A4B-it-GGUF:Q4_K_M"
+serving:
+  entries:
+    - engine: "llama.cpp"
+      type: "Container"
+      modules_supported:
+        - thor_t5000
+        - thor_t4000
+        - orin_agx_64
+      serve_command_orin: |-
+        sudo docker run -it --rm --pull always \
+          --runtime=nvidia --network host \
+          -v $HOME/.cache/huggingface:/root/.cache/huggingface \
+          ghcr.io/nvidia-ai-iot/llama_cpp:gemma4-jetson-orin \
+          llama-server -hf ggml-org/gemma-4-26B-A4B-it-GGUF:Q4_K_M
+      serve_command_thor: |-
+        sudo docker run -it --rm --pull always \
+          --runtime=nvidia --network host \
+          -v $HOME/.cache/huggingface:/root/.cache/huggingface \
+          ghcr.io/nvidia-ai-iot/llama_cpp:gemma4-jetson-thor \
+          llama-server -hf ggml-org/gemma-4-26B-A4B-it-GGUF:Q4_K_M
 ---
 
 Gemma 4 26B-A4B is a larger Gemma 4 variant that can be served on Jetson with `llama.cpp`. Google presents this model as the latency-optimized high-end option in the family: a Mixture-of-Experts model that targets much better throughput than a dense model of similar total size.

--- a/src/content/models/gemma4-31b.md
+++ b/src/content/models/gemma4-31b.md
@@ -14,11 +14,26 @@ model_size: "18.7GB"
 hf_checkpoint: "ggml-org/gemma-4-31B-it-GGUF"
 huggingface_url: "https://huggingface.co/google/gemma-4-31B-it"
 minimum_jetson: "AGX Orin"
-supported_inference_engines:
-  - engine: "llama.cpp"
-    type: "Container"
-    run_command_orin: "sudo docker run -it --rm --pull always --runtime=nvidia --network host -v $HOME/.cache/huggingface:/root/.cache/huggingface ghcr.io/nvidia-ai-iot/llama_cpp:gemma4-jetson-orin llama-server -hf ggml-org/gemma-4-31B-it-GGUF:Q4_K_M"
-    run_command_thor: "sudo docker run -it --rm --pull always --runtime=nvidia --network host -v $HOME/.cache/huggingface:/root/.cache/huggingface ghcr.io/nvidia-ai-iot/llama_cpp:gemma4-jetson-thor llama-server -hf ggml-org/gemma-4-31B-it-GGUF:Q4_K_M"
+serving:
+  entries:
+    - engine: "llama.cpp"
+      type: "Container"
+      modules_supported:
+        - thor_t5000
+        - thor_t4000
+        - orin_agx_64
+      serve_command_orin: |-
+        sudo docker run -it --rm --pull always \
+          --runtime=nvidia --network host \
+          -v $HOME/.cache/huggingface:/root/.cache/huggingface \
+          ghcr.io/nvidia-ai-iot/llama_cpp:gemma4-jetson-orin \
+          llama-server -hf ggml-org/gemma-4-31B-it-GGUF:Q4_K_M
+      serve_command_thor: |-
+        sudo docker run -it --rm --pull always \
+          --runtime=nvidia --network host \
+          -v $HOME/.cache/huggingface:/root/.cache/huggingface \
+          ghcr.io/nvidia-ai-iot/llama_cpp:gemma4-jetson-thor \
+          llama-server -hf ggml-org/gemma-4-31B-it-GGUF:Q4_K_M
 ---
 
 Gemma 4 31B is the largest model in the current Gemma 4 set here, and it can be served on Jetson with `llama.cpp`. In Google's launch post, 31B is the flagship dense model in the family, aimed at the best possible raw quality for local reasoning, coding, and agentic workflows.

--- a/src/content/models/gemma4-e2b.md
+++ b/src/content/models/gemma4-e2b.md
@@ -14,11 +14,28 @@ model_size: "5.0GB"
 hf_checkpoint: "ggml-org/gemma-4-E2B-it-GGUF"
 huggingface_url: "https://huggingface.co/google/gemma-4-E2B-it"
 minimum_jetson: "Orin Nano"
-supported_inference_engines:
-  - engine: "llama.cpp"
-    type: "Container"
-    run_command_orin: "sudo docker run -it --rm --pull always --runtime=nvidia --network host -v $HOME/.cache/huggingface:/root/.cache/huggingface ghcr.io/nvidia-ai-iot/llama_cpp:gemma4-jetson-orin llama-server -hf ggml-org/gemma-4-E2B-it-GGUF:Q8_0"
-    run_command_thor: "sudo docker run -it --rm --pull always --runtime=nvidia --network host -v $HOME/.cache/huggingface:/root/.cache/huggingface ghcr.io/nvidia-ai-iot/llama_cpp:gemma4-jetson-thor llama-server -hf ggml-org/gemma-4-E2B-it-GGUF:Q8_0"
+serving:
+  entries:
+    - engine: "llama.cpp"
+      type: "Container"
+      modules_supported:
+        - thor_t5000
+        - thor_t4000
+        - orin_agx_64
+        - orin_nx_16
+        - orin_nano_8
+      serve_command_orin: |-
+        sudo docker run -it --rm --pull always \
+          --runtime=nvidia --network host \
+          -v $HOME/.cache/huggingface:/root/.cache/huggingface \
+          ghcr.io/nvidia-ai-iot/llama_cpp:gemma4-jetson-orin \
+          llama-server -hf ggml-org/gemma-4-E2B-it-GGUF:Q8_0
+      serve_command_thor: |-
+        sudo docker run -it --rm --pull always \
+          --runtime=nvidia --network host \
+          -v $HOME/.cache/huggingface:/root/.cache/huggingface \
+          ghcr.io/nvidia-ai-iot/llama_cpp:gemma4-jetson-thor \
+          llama-server -hf ggml-org/gemma-4-E2B-it-GGUF:Q8_0
 ---
 
 Gemma 4 E2B is the smallest variant in the Gemma 4 family. Google positions E2B as an edge-first model for low-latency, low-memory deployments where efficiency matters more than absolute model size.

--- a/src/content/models/gemma4-e4b.md
+++ b/src/content/models/gemma4-e4b.md
@@ -13,17 +13,33 @@ precision: "Q4_K_M GGUF"
 model_size: "5.3GB"
 hf_checkpoint: "ggml-org/gemma-4-E4B-it-GGUF"
 huggingface_url: "https://huggingface.co/google/gemma-4-E4B-it"
-minimum_jetson: "Orin Nano"
-supported_inference_engines:
-  - engine: "llama.cpp"
-    type: "Container"
-    run_command_orin: "sudo docker run -it --rm --pull always --runtime=nvidia --network host -v $HOME/.cache/huggingface:/root/.cache/huggingface ghcr.io/nvidia-ai-iot/llama_cpp:gemma4-jetson-orin llama-server -hf ggml-org/gemma-4-E4B-it-GGUF:Q4_K_M"
-    run_command_thor: "sudo docker run -it --rm --pull always --runtime=nvidia --network host -v $HOME/.cache/huggingface:/root/.cache/huggingface ghcr.io/nvidia-ai-iot/llama_cpp:gemma4-jetson-thor llama-server -hf ggml-org/gemma-4-E4B-it-GGUF:Q4_K_M"
+minimum_jetson: "Orin NX"
+serving:
+  entries:
+    - engine: "llama.cpp"
+      type: "Container"
+      modules_supported:
+        - thor_t5000
+        - thor_t4000
+        - orin_agx_64
+        - orin_nx_16
+      serve_command_orin: |-
+        sudo docker run -it --rm --pull always \
+          --runtime=nvidia --network host \
+          -v $HOME/.cache/huggingface:/root/.cache/huggingface \
+          ghcr.io/nvidia-ai-iot/llama_cpp:gemma4-jetson-orin \
+          llama-server -hf ggml-org/gemma-4-E4B-it-GGUF:Q4_K_M
+      serve_command_thor: |-
+        sudo docker run -it --rm --pull always \
+          --runtime=nvidia --network host \
+          -v $HOME/.cache/huggingface:/root/.cache/huggingface \
+          ghcr.io/nvidia-ai-iot/llama_cpp:gemma4-jetson-thor \
+          llama-server -hf ggml-org/gemma-4-E4B-it-GGUF:Q4_K_M
 ---
 
 Gemma 4 E4B is a lightweight Gemma 4 model that can be served locally on Jetson with `llama.cpp`. In Google's launch material, E4B is framed as the stronger edge-focused sibling to E2B, combining on-device efficiency with materially better coding, reasoning, and multimodal performance.
 
-- Local coding assistants on Orin Nano, Orin NX, or AGX Orin
+- Local coding assistants on Orin NX, AGX Orin, or Thor
 - Multimodal document and screen-understanding with optional voice input
 - Tool-using assistants that need better reasoning than E2B
 - A balanced default for edge AI demos or products that need better quality without moving to the larger models


### PR DESCRIPTION
Migrate gemma4-* model pages from `supported_inference_engines` format to `serving.entries` format with serve_command_orin/thor. 

Set `modules_supported` from validated llama.cpp matrix (E2B all matrix tabs; E4B excludes Orin Nano 8GB; 26B-A4B and 31B AGX+Thor only). Align E4B minimum_jetson and intro bullet with matrix.