### PR TITLE
fix(ui): align serve matrix default engine with catalog module coverage

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -7,6 +7,19 @@ import rehypeMermaid from 'rehype-mermaid';
 export default defineConfig({
   integrations: [tailwind(), mdx(), sitemap()],
   site: 'https://www.jetson-ai-lab.com',
+  /** Reduce dev restarts from tooling writing under the repo (Windows file watchers are noisy). */
+  vite: {
+    server: {
+      watch: {
+        ignored: [
+          '**/.cursor/**',
+          '**/_merge_backup/**',
+          '**/dist/**',
+          '**/node_modules/**',
+        ],
+      },
+    },
+  },
   markdown: {
     syntaxHighlight: {
       type: 'shiki',

--- a/src/components/ModelCallSection.astro
+++ b/src/components/ModelCallSection.astro
@@ -91,7 +91,8 @@ const showCallApiStyleTabs =
 			Call the model over Web API
 		</h3>
 		<p class="text-sm text-nvidia-gray-600 mb-8">
-			Copy the command below and paste into your terminal to make a Web API request to the model you just served.
+			Copy a client command below and paste it into your terminal to make a Web API request to the model you just
+			served.
 		</p>
 
 		{ccIntro && fromFrontmatter.length > 0 && (
@@ -265,7 +266,7 @@ const showCallApiStyleTabs =
 												d="M8 5H6a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2v-1M8 5a2 2 0 002 2h2a2 2 0 002-2M8 5a2 2 0 012-2h2a2 2 0 012 2m0 0h2a2 2 0 012 2v3m2 4H10m0 0l3-3m-3 3l3 3"
 											/>
 										</svg>
-										<span data-call-copy-label>Copy command</span>
+										<span data-call-copy-label>Copy client command</span>
 									</button>
 									<pre
 										class="text-sm font-mono text-slate-200 whitespace-pre-wrap break-words [overflow-wrap:anywhere] p-4 m-0"
@@ -322,7 +323,7 @@ const showCallApiStyleTabs =
 						callCopyLabelTimer = null;
 					}
 					root.querySelectorAll<HTMLElement>('[data-call-copy-label]').forEach((el) => {
-						el.textContent = 'Copy command';
+						el.textContent = 'Copy client command';
 					});
 				}
 
@@ -488,7 +489,7 @@ const showCallApiStyleTabs =
 						if (label) {
 							label.textContent = 'Copied';
 							callCopyLabelTimer = setTimeout(() => {
-								label.textContent = 'Copy command';
+								label.textContent = 'Copy client command';
 								callCopyLabelTimer = null;
 							}, 1200);
 						}

--- a/src/components/ModelOneShotSection.astro
+++ b/src/components/ModelOneShotSection.astro
@@ -244,7 +244,7 @@ const panelConfigJson = JSON.stringify({
 														d="M8 5H6a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2v-1M8 5a2 2 0 002 2h2a2 2 0 002-2M8 5a2 2 0 012-2h2a2 2 0 012 2m0 0h2a2 2 0 012 2v3m2 4H10m0 0l3-3m-3 3l3 3"
 													/>
 												</svg>
-												<span data-one-shot-copy-label>Copy</span>
+												<span data-one-shot-copy-label>Copy inference command</span>
 											</button>
 											<pre
 												class="text-sm font-mono text-slate-200 whitespace-pre-wrap break-words [overflow-wrap:anywhere] p-4 m-0 min-h-[8rem]"

--- a/src/components/ModelServeSection.astro
+++ b/src/components/ModelServeSection.astro
@@ -316,7 +316,7 @@ const servePanelEngineRows = sortedEngines.map((e) => ({
 											<svg class="w-3.5 h-3.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
 												<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 5H6a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2v-1M8 5a2 2 0 002 2h2a2 2 0 002-2M8 5a2 2 0 012-2h2a2 2 0 012 2m0 0h2a2 2 0 012 2v3m2 4H10m0 0l3-3m-3 3l3 3" />
 											</svg>
-											<span data-inference-copy-label>Copy command</span>
+											<span data-inference-copy-label>Copy serve command</span>
 										</button>
 										<pre
 											class="text-sm font-mono text-slate-200 whitespace-pre-wrap break-words [overflow-wrap:anywhere] p-4 m-0 min-h-[8rem]"
@@ -454,7 +454,7 @@ const servePanelEngineRows = sortedEngines.map((e) => ({
 				inferenceCopyLabelTimer = null;
 			}
 			const label = copyBtn?.querySelector('[data-inference-copy-label]');
-			if (label) label.textContent = 'Copy command';
+			if (label) label.textContent = 'Copy serve command';
 		}
 
 		function moduleMeta(id: string) {
@@ -656,7 +656,7 @@ const servePanelEngineRows = sortedEngines.map((e) => ({
 				}
 				label.textContent = 'Copied';
 				inferenceCopyLabelTimer = setTimeout(() => {
-					label.textContent = 'Copy command';
+					label.textContent = 'Copy serve command';
 					inferenceCopyLabelTimer = null;
 				}, 1200);
 			}

--- a/src/components/RunCommand.astro
+++ b/src/components/RunCommand.astro
@@ -413,12 +413,13 @@ const engineImages = engineImagesOrin;
                                     type="button"
                                     data-copy
                                     data-run-copy
+                                    data-run-copy-reset-label="Copy serve command"
                                     class="absolute top-2 right-2 z-10 flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg bg-white/65 backdrop-blur-sm border border-white/40 text-nvidia-gray-800 hover:bg-white/80 hover:border-nvidia-green/60 hover:text-nvidia-green transition-all shadow-md text-xs font-bold"
                                 >
                                     <svg class="w-3.5 h-3.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 5H6a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2v-1M8 5a2 2 0 002 2h2a2 2 0 002-2M8 5a2 2 0 012-2h2a2 2 0 012 2m0 0h2a2 2 0 012 2v3m2 4H10m0 0l3-3m-3 3l3 3" />
                                     </svg>
-                                    <span data-run-copy-label>Copy command</span>
+                                    <span data-run-copy-label>Copy serve command</span>
                                 </button>
                                 <pre class="h-full max-h-[min(42vh,380px)] min-w-0 w-full max-w-full p-4 sm:p-5 text-left text-sm font-mono leading-relaxed overflow-x-hidden overflow-y-auto text-slate-200 scrollbar-thin scrollbar-thumb-slate-700 scrollbar-track-transparent whitespace-pre-wrap break-words [overflow-wrap:anywhere]"><code data-snippet class="block w-full max-w-full text-left">Loading command...</code></pre>
                             </div>
@@ -528,12 +529,13 @@ const engineImages = engineImagesOrin;
                                 type="button"
                                 data-copy
                                 data-run-copy
+                                data-run-copy-reset-label="Copy inference command"
                                 class="absolute top-2 right-2 z-10 flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg bg-white/65 backdrop-blur-sm border border-white/40 text-nvidia-gray-800 hover:bg-white/80 hover:border-nvidia-green/60 hover:text-nvidia-green transition-all shadow-md text-xs font-bold"
                             >
                                 <svg class="w-3.5 h-3.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 5H6a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2v-1M8 5a2 2 0 002 2h2a2 2 0 002-2M8 5a2 2 0 012-2h2a2 2 0 012 2m0 0h2a2 2 0 012 2v3m2 4H10m0 0l3-3m-3 3l3 3" />
                                 </svg>
-                                <span data-run-copy-label>Copy command</span>
+                                <span data-run-copy-label>Copy inference command</span>
                             </button>
                             <pre class="h-full max-h-[min(42vh,380px)] min-w-0 w-full max-w-full p-4 sm:p-5 text-left text-sm font-mono leading-relaxed overflow-x-hidden overflow-y-auto text-slate-200 scrollbar-thin scrollbar-thumb-slate-700 scrollbar-track-transparent whitespace-pre-wrap break-words [overflow-wrap:anywhere]"><code data-snippet class="block w-full max-w-full text-left">Loading command...</code></pre>
                         </div>
@@ -651,12 +653,13 @@ const engineImages = engineImagesOrin;
                                 type="button"
                                 data-copy
                                 data-run-copy
+                                data-run-copy-reset-label="Copy serve command"
                                 class="absolute top-2 right-2 z-10 flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg bg-white/65 backdrop-blur-sm border border-white/40 text-nvidia-gray-800 hover:bg-white/80 hover:border-nvidia-green/60 hover:text-nvidia-green transition-all shadow-md text-xs font-bold"
                             >
                                 <svg class="w-3.5 h-3.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 5H6a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2v-1M8 5a2 2 0 002 2h2a2 2 0 002-2M8 5a2 2 0 012-2h2a2 2 0 012 2m0 0h2a2 2 0 012 2v3m2 4H10m0 0l3-3m-3 3l3 3" />
                                 </svg>
-                                <span data-run-copy-label>Copy command</span>
+                                <span data-run-copy-label>Copy serve command</span>
                             </button>
                             <pre class="h-full max-h-[min(50vh,420px)] min-w-0 w-full max-w-full p-4 sm:p-5 text-left text-sm font-mono leading-relaxed overflow-x-hidden overflow-y-auto text-slate-200 scrollbar-thin scrollbar-thumb-slate-700 scrollbar-track-transparent whitespace-pre-wrap break-words [overflow-wrap:anywhere]"><code data-snippet class="block w-full max-w-full text-left">Loading command...</code></pre>
                         </div>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1035,11 +1035,12 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
               });
               var label = copyBtn.querySelector('[data-run-copy-label]');
               var original = label ? (label.textContent || '') : (copyBtn.textContent || '');
+              var resetLabel = copyBtn.getAttribute('data-run-copy-reset-label') || 'Copy serve command';
               if (label) label.textContent = 'Copied';
               else copyBtn.textContent = 'Copied';
               setTimeout(function () {
-                if (label) label.textContent = original || 'Copy command';
-                else copyBtn.textContent = original || 'Copy';
+                if (label) label.textContent = original || resetLabel;
+                else copyBtn.textContent = original || resetLabel;
               }, 1200);
             }
             return;

--- a/src/lib/modelFrontmatterAdapter.ts
+++ b/src/lib/modelFrontmatterAdapter.ts
@@ -1,4 +1,9 @@
-import type { SupportedEngineEntry } from './inferenceCommands';
+import {
+	engineSupportsModule,
+	serveCommandForMatrixCell,
+	visibleModulesForEngines,
+	type SupportedEngineEntry,
+} from './inferenceCommands';
 
 /** Shape needed to resolve engines (matches model collection data; avoid importing content/config from lib). */
 export interface ModelEnginesSource {
@@ -47,8 +52,32 @@ export function getSupportedInferenceEngines(data: ModelEnginesSource): Supporte
 	return data.supported_inference_engines ?? [];
 }
 
+/** Matrix cells with a non-empty serve command (same idea as catalog union, per engine). */
+function runnableMatrixCellCountForEngine(
+	allEngines: SupportedEngineEntry[],
+	entry: SupportedEngineEntry
+): number {
+	const mods = visibleModulesForEngines(allEngines);
+	let n = 0;
+	for (const mod of mods) {
+		if (!engineSupportsModule(entry, mod.id)) continue;
+		if (!serveCommandForMatrixCell(entry, mod).trim()) continue;
+		n++;
+	}
+	return n;
+}
+
+/**
+ * Order engines for the serve matrix / Run modal.
+ * Prefer an engine that supports **more** Jetson module tabs (aligns default UI with catalog “any engine” checks),
+ * then vLLM among ties, then name.
+ */
 export function sortEnginesForUi(engines: SupportedEngineEntry[]): SupportedEngineEntry[] {
+	if (engines.length <= 1) return [...engines];
 	return [...engines].sort((a, b) => {
+		const ca = runnableMatrixCellCountForEngine(engines, a);
+		const cb = runnableMatrixCellCountForEngine(engines, b);
+		if (cb !== ca) return cb - ca;
 		if (a.engine === 'vLLM') return -1;
 		if (b.engine === 'vLLM') return 1;
 		return a.engine.localeCompare(b.engine);


### PR DESCRIPTION
Sort inference engines by runnable matrix cell count so the default engine matches catalog union (e.g. Gemma 4 E2B Orin Nano 8GB via llama.cpp before vLLM).
<img width="1536" height="1040" alt="image" src="https://github.com/user-attachments/assets/21e273a7-b519-4aac-a06a-112236844de3" />

Rename copy controls: Copy serve command, Copy client command, Copy inference command; run modal reset labels via data-run-copy-reset-label.
