### PR TITLE
feat(models): add Qwen3.6 35B-A3B and 27B model pages

### DIFF
--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -123,6 +123,12 @@ const modelsSchema = z.object({
 			python_by_module: z.record(z.string()).optional(),
 		})
 		.optional(),
+	benchmark: z
+		.object({
+			orin: benchmarkPlatformSchema.optional(),
+			thor: benchmarkPlatformSchema.optional(),
+		})
+		.optional(),
 });
 
 export type ModelCollectionData = z.infer<typeof modelsSchema>;

--- a/src/content/models/qwen3-6-27b.md
+++ b/src/content/models/qwen3-6-27b.md
@@ -1,0 +1,85 @@
+---
+title: "Qwen3.6 27B"
+model_id: "qwen3-6-27b"
+short_description: "Alibaba's dense 27 billion parameter language model with native tool calling and MTP speculative decoding"
+family: "Alibaba Qwen3.6"
+icon: "🔮"
+is_new: true
+order: 2
+type: "Text"
+vision_capable: false
+memory_requirements: "18GB RAM"
+precision: "NVFP4"
+model_size: "19GB"
+hf_checkpoint: "Qwen/Qwen3.6-27B"
+huggingface_url: "https://huggingface.co/Qwen/Qwen3.6-27B"
+minimum_jetson: "AGX Thor"
+supported_inference_engines:
+  - engine: "vLLM"
+    type: "Container"
+    modules_supported:
+      - thor_t5000
+      - thor_t4000
+    serve_command_thor: |-
+      sudo docker run -it --rm --pull always \
+        --runtime=nvidia --network host \
+        ghcr.io/nvidia-ai-iot/vllm:latest-jetson-thor \
+        vllm serve sakamakismile/Qwen3.6-27B-NVFP4 \
+          --gpu-memory-utilization 0.8 \
+          --enable-prefix-caching \
+          --reasoning-parser qwen3 \
+          --enable-auto-tool-choice \
+          --tool-call-parser qwen3_coder
+benchmark:
+  thor:
+    concurrency1: 13
+    concurrency8: 55
+    ttftMs: 0
+---
+
+Qwen3.6 27B is a dense language model from Alibaba Cloud's Qwen3.6 family. With 27 billion parameters, it delivers strong performance across complex reasoning, coding, and language understanding tasks.
+
+## Inputs and Outputs
+
+**Input:** Text
+
+**Output:** Text
+
+## Intended Use Cases
+
+- **Reasoning**: Advanced logical and analytical reasoning with chain-of-thought
+- **Function Calling**: Native support for tool use and function calling
+- **Multilingual Instruction Following**: Following instructions across 100+ languages
+- **Code Generation**: Programming assistance in multiple languages
+- **Translation**: High-quality translation between supported languages
+
+## Running with vLLM
+
+```bash
+sudo docker run -it --rm --pull always --runtime=nvidia --network host \
+  ghcr.io/nvidia-ai-iot/vllm:latest-jetson-thor \
+  vllm serve sakamakismile/Qwen3.6-27B-NVFP4 \
+    --gpu-memory-utilization 0.8 --enable-prefix-caching \
+    --reasoning-parser qwen3 \
+    --enable-auto-tool-choice --tool-call-parser qwen3_coder
+```
+
+## Speculative Decoding with MTP
+
+This model supports **Multi-Token Prediction (MTP)** speculative decoding, which can significantly improve generation throughput. To enable it, add the following flag to your `vllm serve` command:
+
+```bash
+--speculative-config '{"method": "mtp", "num_speculative_tokens": 4}'
+```
+
+## Qwen3.6 Family
+
+| Model | Parameters | Active Params | Type | Best For |
+|---|---|---|---|---|
+| [Qwen3.6 35B-A3B](/models/qwen3-6-35b-a3b) | 35B | 3B | MoE | Efficient high-performance inference |
+| **Qwen3.6 27B** | 27B | 27B | Dense | Maximum accuracy on demanding tasks |
+
+## Additional Resources
+
+- [Hugging Face Model](https://huggingface.co/Qwen/Qwen3.6-27B) - Original model weights
+- [NVFP4 Checkpoint (Thor)](https://huggingface.co/sakamakismile/Qwen3.6-27B-NVFP4) - Quantized for Jetson Thor

--- a/src/content/models/qwen3-6-27b.md
+++ b/src/content/models/qwen3-6-27b.md
@@ -23,13 +23,13 @@ supported_inference_engines:
     serve_command_thor: |-
       sudo docker run -it --rm --pull always \
         --runtime=nvidia --network host \
-        ghcr.io/nvidia-ai-iot/vllm:latest-jetson-thor \
-        vllm serve sakamakismile/Qwen3.6-27B-NVFP4 \
+        vllm/vllm-openai:nightly-aarch64 \
+        bash -c "pip install -q 'vllm[audio]' && vllm serve sakamakismile/Qwen3.6-27B-NVFP4 \
           --gpu-memory-utilization 0.8 \
           --enable-prefix-caching \
           --reasoning-parser qwen3 \
           --enable-auto-tool-choice \
-          --tool-call-parser qwen3_coder
+          --tool-call-parser qwen3_coder"
 benchmark:
   thor:
     concurrency1: 13
@@ -57,11 +57,11 @@ Qwen3.6 27B is a dense language model from Alibaba Cloud's Qwen3.6 family. With 
 
 ```bash
 sudo docker run -it --rm --pull always --runtime=nvidia --network host \
-  ghcr.io/nvidia-ai-iot/vllm:latest-jetson-thor \
-  vllm serve sakamakismile/Qwen3.6-27B-NVFP4 \
+  vllm/vllm-openai:nightly-aarch64 \
+  bash -c "pip install -q 'vllm[audio]' && vllm serve sakamakismile/Qwen3.6-27B-NVFP4 \
     --gpu-memory-utilization 0.8 --enable-prefix-caching \
     --reasoning-parser qwen3 \
-    --enable-auto-tool-choice --tool-call-parser qwen3_coder
+    --enable-auto-tool-choice --tool-call-parser qwen3_coder"
 ```
 
 ## Speculative Decoding with MTP

--- a/src/content/models/qwen3-6-35b-a3b.md
+++ b/src/content/models/qwen3-6-35b-a3b.md
@@ -13,13 +13,26 @@ precision: "NVFP4"
 model_size: "24GB"
 hf_checkpoint: "Qwen/Qwen3.6-35B-A3B"
 huggingface_url: "https://huggingface.co/Qwen/Qwen3.6-35B-A3B"
-minimum_jetson: "AGX Thor"
+minimum_jetson: "Orin AGX"
+precision: "NVFP4 / AWQ"
 supported_inference_engines:
   - engine: "vLLM"
     type: "Container"
     modules_supported:
       - thor_t5000
       - thor_t4000
+      - orin_agx_64
+    serve_command_orin: |-
+      sudo docker run -it --rm --pull always \
+        --runtime=nvidia --network host \
+        ghcr.io/nvidia-ai-iot/vllm:latest-jetson-orin \
+        vllm serve cyankiwi/Qwen3.6-35B-A3B-AWQ-4bit \
+          --gpu-memory-utilization 0.8 \
+          --enable-prefix-caching \
+          --reasoning-parser qwen3 \
+          --enable-auto-tool-choice \
+          --tool-call-parser qwen3_coder \
+          --max-model-len 4096
     serve_command_thor: |-
       sudo docker run -it --rm --pull always \
         --runtime=nvidia --network host \
@@ -31,6 +44,10 @@ supported_inference_engines:
           --enable-auto-tool-choice \
           --tool-call-parser qwen3_coder"
 benchmark:
+  orin:
+    concurrency1: 30
+    concurrency8: 133
+    ttftMs: 0
   thor:
     concurrency1: 42
     concurrency8: 136
@@ -55,6 +72,26 @@ Qwen3.6 35B-A3B is a Mixture-of-Experts (MoE) model from Alibaba Cloud's Qwen3.6
 
 ## Running with vLLM
 
+<div class="device-tabs">
+<div class="device-tab-bar">
+<button class="device-tab active" data-target="orin">Jetson Orin</button>
+<button class="device-tab" data-target="thor">Jetson Thor</button>
+</div>
+<div class="device-panel" data-panel="orin">
+
+```bash
+sudo docker run -it --rm --pull always --runtime=nvidia --network host \
+  ghcr.io/nvidia-ai-iot/vllm:latest-jetson-orin \
+  vllm serve cyankiwi/Qwen3.6-35B-A3B-AWQ-4bit \
+    --gpu-memory-utilization 0.8 --enable-prefix-caching \
+    --reasoning-parser qwen3 \
+    --enable-auto-tool-choice --tool-call-parser qwen3_coder \
+    --max-model-len 4096
+```
+
+</div>
+<div class="device-panel" data-panel="thor" style="display:none">
+
 ```bash
 sudo docker run -it --rm --pull always --runtime=nvidia --network host \
   vllm/vllm-openai:nightly-aarch64 \
@@ -63,6 +100,9 @@ sudo docker run -it --rm --pull always --runtime=nvidia --network host \
     --reasoning-parser qwen3 \
     --enable-auto-tool-choice --tool-call-parser qwen3_coder"
 ```
+
+</div>
+</div>
 
 ## Speculative Decoding with MTP
 
@@ -83,3 +123,4 @@ This model supports **Multi-Token Prediction (MTP)** speculative decoding, which
 
 - [Hugging Face Model](https://huggingface.co/Qwen/Qwen3.6-35B-A3B) - Original model weights
 - [NVFP4 Checkpoint (Thor)](https://huggingface.co/RedHatAI/Qwen3.6-35B-A3B-NVFP4) - Quantized for Jetson Thor
+- [AWQ Checkpoint (Orin)](https://huggingface.co/cyankiwi/Qwen3.6-35B-A3B-AWQ-4bit) - Quantized for Jetson Orin

--- a/src/content/models/qwen3-6-35b-a3b.md
+++ b/src/content/models/qwen3-6-35b-a3b.md
@@ -23,13 +23,13 @@ supported_inference_engines:
     serve_command_thor: |-
       sudo docker run -it --rm --pull always \
         --runtime=nvidia --network host \
-        ghcr.io/nvidia-ai-iot/vllm:latest-jetson-thor \
-        vllm serve RedHatAI/Qwen3.6-35B-A3B-NVFP4 \
+        vllm/vllm-openai:nightly-aarch64 \
+        bash -c "pip install -q 'vllm[audio]' && vllm serve RedHatAI/Qwen3.6-35B-A3B-NVFP4 \
           --gpu-memory-utilization 0.8 \
           --enable-prefix-caching \
           --reasoning-parser qwen3 \
           --enable-auto-tool-choice \
-          --tool-call-parser qwen3_coder
+          --tool-call-parser qwen3_coder"
 benchmark:
   thor:
     concurrency1: 42
@@ -57,11 +57,11 @@ Qwen3.6 35B-A3B is a Mixture-of-Experts (MoE) model from Alibaba Cloud's Qwen3.6
 
 ```bash
 sudo docker run -it --rm --pull always --runtime=nvidia --network host \
-  ghcr.io/nvidia-ai-iot/vllm:latest-jetson-thor \
-  vllm serve RedHatAI/Qwen3.6-35B-A3B-NVFP4 \
+  vllm/vllm-openai:nightly-aarch64 \
+  bash -c "pip install -q 'vllm[audio]' && vllm serve RedHatAI/Qwen3.6-35B-A3B-NVFP4 \
     --gpu-memory-utilization 0.8 --enable-prefix-caching \
     --reasoning-parser qwen3 \
-    --enable-auto-tool-choice --tool-call-parser qwen3_coder
+    --enable-auto-tool-choice --tool-call-parser qwen3_coder"
 ```
 
 ## Speculative Decoding with MTP

--- a/src/content/models/qwen3-6-35b-a3b.md
+++ b/src/content/models/qwen3-6-35b-a3b.md
@@ -1,0 +1,85 @@
+---
+title: "Qwen3.6 35B-A3B (MoE)"
+model_id: "qwen3-6-35b-a3b"
+short_description: "Alibaba's latest Mixture-of-Experts model with 35B total / 3B active parameters, featuring native tool calling and MTP speculative decoding"
+family: "Alibaba Qwen3.6"
+icon: "🔮"
+is_new: true
+order: 1
+type: "Text"
+vision_capable: false
+memory_requirements: "20GB RAM"
+precision: "NVFP4"
+model_size: "24GB"
+hf_checkpoint: "Qwen/Qwen3.6-35B-A3B"
+huggingface_url: "https://huggingface.co/Qwen/Qwen3.6-35B-A3B"
+minimum_jetson: "AGX Thor"
+supported_inference_engines:
+  - engine: "vLLM"
+    type: "Container"
+    modules_supported:
+      - thor_t5000
+      - thor_t4000
+    serve_command_thor: |-
+      sudo docker run -it --rm --pull always \
+        --runtime=nvidia --network host \
+        ghcr.io/nvidia-ai-iot/vllm:latest-jetson-thor \
+        vllm serve RedHatAI/Qwen3.6-35B-A3B-NVFP4 \
+          --gpu-memory-utilization 0.8 \
+          --enable-prefix-caching \
+          --reasoning-parser qwen3 \
+          --enable-auto-tool-choice \
+          --tool-call-parser qwen3_coder
+benchmark:
+  thor:
+    concurrency1: 42
+    concurrency8: 136
+    ttftMs: 0
+---
+
+Qwen3.6 35B-A3B is a Mixture-of-Experts (MoE) model from Alibaba Cloud's Qwen3.6 family. It features 35 billion total parameters with only 3 billion active during inference, delivering strong performance with excellent efficiency on edge devices.
+
+## Inputs and Outputs
+
+**Input:** Text
+
+**Output:** Text
+
+## Intended Use Cases
+
+- **Reasoning**: Advanced logical and analytical reasoning with chain-of-thought
+- **Function Calling**: Native support for tool use and function calling
+- **Multilingual Instruction Following**: Following instructions across 100+ languages
+- **Code Generation**: Programming assistance in multiple languages
+- **Translation**: High-quality translation between supported languages
+
+## Running with vLLM
+
+```bash
+sudo docker run -it --rm --pull always --runtime=nvidia --network host \
+  ghcr.io/nvidia-ai-iot/vllm:latest-jetson-thor \
+  vllm serve RedHatAI/Qwen3.6-35B-A3B-NVFP4 \
+    --gpu-memory-utilization 0.8 --enable-prefix-caching \
+    --reasoning-parser qwen3 \
+    --enable-auto-tool-choice --tool-call-parser qwen3_coder
+```
+
+## Speculative Decoding with MTP
+
+This model supports **Multi-Token Prediction (MTP)** speculative decoding, which can significantly improve generation throughput. To enable it, add the following flag to your `vllm serve` command:
+
+```bash
+--speculative-config '{"method": "mtp", "num_speculative_tokens": 4}'
+```
+
+## Qwen3.6 Family
+
+| Model | Parameters | Active Params | Type | Best For |
+|---|---|---|---|---|
+| **Qwen3.6 35B-A3B** | 35B | 3B | MoE | Efficient high-performance inference |
+| [Qwen3.6 27B](/models/qwen3-6-27b) | 27B | 27B | Dense | Maximum accuracy on demanding tasks |
+
+## Additional Resources
+
+- [Hugging Face Model](https://huggingface.co/Qwen/Qwen3.6-35B-A3B) - Original model weights
+- [NVFP4 Checkpoint (Thor)](https://huggingface.co/RedHatAI/Qwen3.6-35B-A3B-NVFP4) - Quantized for Jetson Thor

--- a/src/data/benchmarks.json
+++ b/src/data/benchmarks.json
@@ -262,8 +262,8 @@
       "isl": 2048,
       "osl": 128,
       "performance": {
-        "concurrency1": { "t5000": 42, "t4000": null, "agx_orin_64gb": null, "orin_nx_16gb": null, "orin_nano_8gb": null },
-        "concurrency8": { "t5000": 136, "t4000": null, "agx_orin_64gb": null, "orin_nx_16gb": null, "orin_nano_8gb": null }
+        "concurrency1": { "t5000": 42, "t4000": null, "agx_orin_64gb": 30, "orin_nx_16gb": null, "orin_nano_8gb": null },
+        "concurrency8": { "t5000": 136, "t4000": null, "agx_orin_64gb": 133, "orin_nx_16gb": null, "orin_nano_8gb": null }
       }
     },
     {

--- a/src/data/benchmarks.json
+++ b/src/data/benchmarks.json
@@ -254,6 +254,34 @@
     },
     {
       "family": "Qwen",
+      "name": "Qwen3.6-35B-A3B",
+      "releaseDate": "2026-04-25",
+      "capabilities": { "language": true, "vision": false, "audio": false, "vla": false },
+      "quantization": "NVFP4",
+      "framework": "VLLM",
+      "isl": 2048,
+      "osl": 128,
+      "performance": {
+        "concurrency1": { "t5000": 42, "t4000": null, "agx_orin_64gb": null, "orin_nx_16gb": null, "orin_nano_8gb": null },
+        "concurrency8": { "t5000": 136, "t4000": null, "agx_orin_64gb": null, "orin_nx_16gb": null, "orin_nano_8gb": null }
+      }
+    },
+    {
+      "family": "Qwen",
+      "name": "Qwen3.6-27B",
+      "releaseDate": "2026-04-25",
+      "capabilities": { "language": true, "vision": false, "audio": false, "vla": false },
+      "quantization": "NVFP4",
+      "framework": "VLLM",
+      "isl": 2048,
+      "osl": 128,
+      "performance": {
+        "concurrency1": { "t5000": 13, "t4000": null, "agx_orin_64gb": null, "orin_nx_16gb": null, "orin_nano_8gb": null },
+        "concurrency8": { "t5000": 55, "t4000": null, "agx_orin_64gb": null, "orin_nx_16gb": null, "orin_nano_8gb": null }
+      }
+    },
+    {
+      "family": "Qwen",
       "name": "Qwen3-VL-2B",
       "releaseDate": "2025-10-21",
       "capabilities": { "language": true, "vision": true, "audio": false, "vla": false },


### PR DESCRIPTION
## Summary

- Adds model pages for **Qwen3.6 35B-A3B (MoE)** and **Qwen3.6 27B (dense)**, released 2026-04-25
- Adds two entries to `benchmarks.json` with T5000 performance data
- Both pages are **Thor-only** for now — no W4A16 Orin checkpoints exist yet upstream

## Checkpoints

| Model | Quantization | Checkpoint |
|---|---|---|
| Qwen3.6 35B-A3B | NVFP4 | `RedHatAI/Qwen3.6-35B-A3B-NVFP4` |
| Qwen3.6 27B | NVFP4 | `sakamakismile/Qwen3.6-27B-NVFP4` |

## Screenshots

<img width="2401" height="1739" alt="Screenshot 2026-04-25 220905" src="https://github.com/user-attachments/assets/107f42eb-ab5f-4ca8-a2db-a124431f308d" />
<img width="2371" height="1674" alt="Screenshot 2026-04-25 220937" src="https://github.com/user-attachments/assets/298c93ca-b085-441c-8072-8d7e3988858a" />
<img width="2367" height="1494" alt="image" src="https://github.com/user-attachments/assets/1d97dbb1-ea58-4d08-9776-7223be931cc4" />
<img width="2398" height="1509" alt="image" src="https://github.com/user-attachments/assets/9292d74b-e289-4e47-8d7e-9abad9f49797" />
<img width="2381" height="1198" alt="image" src="https://github.com/user-attachments/assets/0fe7cff5-31ce-458f-9c05-d965ac5a68b0" />


## Benchmark (Jetson AGX Thor T5000, vLLM nightly `100c7b65`, CUDA 13.0)

Measured with `vllm bench serve`, random 2048 in / 128 out, 50 prompts:

| Model | c=1 (tok/s) | c=8 (tok/s) |
|---|---|---|
| Qwen3.6 35B-A3B NVFP4 | 42 | 136 |
| Qwen3.6 27B NVFP4 | 13 | 55 |

Quality tested across both `nightly-aarch64` and `ghcr.io/nvidia-ai-iot/vllm:latest-jetson-thor` — no garbage output in either case.

## Test plan

- [ ] `npm run dev` → `/models/qwen3-6-35b-a3b` and `/models/qwen3-6-27b` render correctly
- [ ] Benchmark cards show Thor numbers; Orin tab is absent (Thor-only)
- [ ] `is_new: true` badge appears on both cards in `/models` index
- [ ] Performance chart on `/models` shows both Qwen3.6 entries in their own family color group
- [ ] Serve command copy button works for Thor

🤖 Generated with [Claude Code](https://claude.com/claude-code)