### PR TITLE
fix(schema): restore benchmarkPlatformSchema def; remove duplicate precision key

### DIFF
--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -65,6 +65,12 @@ const servingEntrySchema = z.object({
 	run_commands_by_module: z.record(z.string()).optional(),
 });
 
+const benchmarkPlatformSchema = z.object({
+	concurrency1: z.number(),
+	concurrency8: z.number(),
+	ttftMs: z.number(),
+});
+
 const modelsSchema = z.object({
 	title: z.string(),
 	model_id: z.string().optional(),

--- a/src/content/models/qwen3-6-35b-a3b.md
+++ b/src/content/models/qwen3-6-35b-a3b.md
@@ -9,7 +9,6 @@ order: 1
 type: "Text"
 vision_capable: false
 memory_requirements: "20GB RAM"
-precision: "NVFP4"
 model_size: "24GB"
 hf_checkpoint: "Qwen/Qwen3.6-35B-A3B"
 huggingface_url: "https://huggingface.co/Qwen/Qwen3.6-35B-A3B"


### PR DESCRIPTION
## Summary

Two build errors introduced by #382 merge:

- `benchmarkPlatformSchema` was referenced in `config.ts` but its definition was dropped during the rebase conflict resolution — restores the `z.object({ concurrency1, concurrency8, ttftMs })` definition
- `qwen3-6-35b-a3b.md` had `precision:` set twice (lines 12 and 17), causing a YAML duplicate key parse error at build time

## Test plan

- [x] `npm run build` passes locally (72 pages built)