### PR TITLE
feat(nn3omni): add Ollama engine with Orin 64GB support, OOM markers, and matrix UI improvements

### DIFF
--- a/src/components/ModelBenchmarkSection.astro
+++ b/src/components/ModelBenchmarkSection.astro
@@ -108,6 +108,7 @@ const ENGINE_COLORS_MAP: Record<string, string> = {
 	'vLLM':      '#30a3ff',
 	'SGLang':    '#d55816',
 	'llama.cpp': '#8899A6',
+	'Ollama':    '#2E2E2E',
 	'Edge-LLM':  '#006666',
 };
 ---
@@ -217,6 +218,7 @@ const ENGINE_COLORS_MAP: Record<string, string> = {
 		'vLLM':      '#30a3ff',
 		'SGLang':    '#d55816',
 		'llama.cpp': '#8899A6',
+		'Ollama':    '#2E2E2E',
 		'Edge-LLM':  '#006666',
 	};
 
@@ -462,6 +464,12 @@ const ENGINE_COLORS_MAP: Record<string, string> = {
 		activeProducts.forEach((prod, gi) => {
 			const cx = groupCx(gi);
 
+			const hasData = bars.some((bar, bi) => {
+				if (!bar.isMain && hiddenSeries.has(bi)) return false;
+				return bar[key][prod.id] != null || bar.dnr?.has(prod.id) || bar.oom?.has(prod.id);
+			});
+			const labelColor = hasData ? '#374151' : '#D1D5DB';
+
 			if (gi > 0) {
 				s += `<line x1="${ml + gi * groupW}" y1="${mt}" x2="${ml + gi * groupW}" y2="${mt + chartH}" stroke="#F9FAFB" stroke-dasharray="3 3"/>`;
 			}
@@ -473,7 +481,7 @@ const ENGINE_COLORS_MAP: Record<string, string> = {
 				const content = part.includes('Orin')
 					? part.replace('Orin', `<tspan font-weight="500">Orin</tspan>`)
 					: part;
-				s += `<text x="${cx}" y="${ly + pi * 17}" text-anchor="middle" fill="#6B7280" font-size="14" font-weight="${fw}">${content}</text>`;
+				s += `<text x="${cx}" y="${ly + pi * 17}" text-anchor="middle" fill="${labelColor}" font-size="14" font-weight="${fw}">${content}</text>`;
 			});
 		});
 

--- a/src/components/ModelServeSection.astro
+++ b/src/components/ModelServeSection.astro
@@ -99,7 +99,10 @@ const servePanelModuleItems: MatrixModuleTabItem[] = visibleModules.map((m) => (
 	iconBadgeMemory: m.iconBadgeMemory,
 	globalDisabled: m.disabled === true,
 }));
-const servePanelTabDisabled = visibleModules.map((m) => moduleTabDisabledForEngine(m, defaultEngineEntry));
+const servePanelTabDisabled = visibleModules.map((m) => {
+	if (m.disabled === true) return true;
+	return !sortedEngines.some((e) => engineSupportsModule(e, m.id));
+});
 const servePanelEngineRows = sortedEngines.map((e) => ({
 	key: e.engine,
 	title: e.engine,

--- a/src/components/matrix/matrixTabStyles.ts
+++ b/src/components/matrix/matrixTabStyles.ts
@@ -94,7 +94,7 @@ export const MATRIX_ENGINE_BTN_SERVE: readonly string[] = [
 	'border-b-[5px] pb-2 -mb-px lg:mb-0 lg:border-b-0 lg:!border-l-[5px] lg:py-2.5 lg:rounded-r-md',
 	'border-b-transparent text-gray-500 cursor-pointer',
 	'hover:text-nvidia-black hover:border-b-gray-300 lg:hover:border-l-gray-300',
-	'disabled:opacity-40 disabled:cursor-not-allowed disabled:pointer-events-none disabled:hover:bg-transparent disabled:text-nvidia-gray-400',
+	'disabled:bg-nvidia-gray-100 disabled:cursor-not-allowed disabled:pointer-events-none disabled:text-nvidia-gray-400 disabled:border-b-transparent disabled:lg:border-l-transparent',
 ];
 
 export const MATRIX_ENGINE_TITLE = 'font-semibold text-sm block';

--- a/src/content/models/nemotron-3-nano-omni.md
+++ b/src/content/models/nemotron-3-nano-omni.md
@@ -68,6 +68,14 @@ supported_inference_engines:
         -v $HOME/.cache/llama.cpp:/data/models/llama.cpp \
         ghcr.io/nvidia-ai-iot/llama_cpp:latest-jetson-thor \
         bash -lc 'MODEL=$(huggingface-downloader ggml-org/Nemotron-3-Nano-Omni-GGUF/nemotron-3-nano-omni-ga_v1.0-Q4_K_M.gguf) && MMPROJ=$(huggingface-downloader ggml-org/Nemotron-3-Nano-Omni-GGUF/mmproj-nemotron-3-nano-omni-ga_v1.0.gguf) && llama-server -m "$MODEL" -mm "$MMPROJ" --ctx-size 8192 --alias my_model --n-gpu-layers 999 --host 0.0.0.0 --port 8080'
+  - engine: "Ollama"
+    type: "Local"
+    modules_supported:
+      - thor_t5000
+      - thor_t4000
+      - orin_agx_64
+    serve_command_thor: ollama run nemotron3:33b-q4_K_M
+    serve_command_orin: ollama run nemotron3:33b-q4_K_M
 benchmark_key: "Nemotron 3 Nano Omni"
 benchmark_series:
   - "Nemotron 3 30B-A3B"
@@ -192,6 +200,14 @@ curl -s http://127.0.0.1:8080/v1/chat/completions \
 ```
 
 > **Note:** `huggingface-downloader` fetches the GGUF model and multimodal projector from `ggml-org/Nemotron-3-Nano-Omni-GGUF`. `-mm "$MMPROJ"` loads the multimodal projector for vision support. `--n-gpu-layers 999` offloads all layers to GPU. `--alias my_model` sets the model name used in API requests. `chat_template_kwargs: {"enable_thinking": true}` activates chain-of-thought reasoning.
+
+## Running with Ollama
+
+Ollama runs the Q4_K_M GGUF directly on the GPU and works on both Jetson Thor and Jetson AGX Orin 64GB.
+
+```bash
+ollama run nemotron3:33b-q4_K_M
+```
 
 ## Running with TensorRT Edge-LLM
 

--- a/src/data/benchmarks.json
+++ b/src/data/benchmarks.json
@@ -294,6 +294,30 @@
               "dgx_spark": null
             }
           }
+        },
+        "Ollama": {
+          "Q4_K_M": {
+            "concurrency1": {
+              "t5000": 27,
+              "t4000": null,
+              "agx_orin_64gb": 17,
+              "orin_nx_16gb": null,
+              "orin_nano_8gb": null,
+              "dgx_spark": null
+            },
+            "concurrency8": {
+              "t5000": 28,
+              "t4000": null,
+              "agx_orin_64gb": 17,
+              "orin_nx_16gb": null,
+              "orin_nano_8gb": null,
+              "dgx_spark": null
+            },
+            "oom": [
+              "orin_nx_16gb",
+              "orin_nano_8gb"
+            ]
+          }
         }
       }
     },


### PR DESCRIPTION
 ## Summary

- Ollama engine for Nemotron 3 Nano Omni — adds ollama run nemotron3:33b-q4_K_M as a serve option, supported on Jetson Thor (T5000/T4000) and Jetson AGX Orin 64GB
- Benchmark data — Ollama Q4_K_M results: T5000 c1=27 / c8=28 tok/s, AGX Orin 64GB c1=17 / c8=17 tok/s; OOM marked for Orin NX 16GB and Orin Nano 8GB
- Matrix widget: module tab enabled state — Orin 64GB tab is now enabled whenever any inference engine supports that module (previously only checked the default/first engine, leaving the tab grayed out even when Ollama covered it)
- Matrix widget: disabled engine styling — unavailable engine rail buttons now show a gray background fill instead of an opacity fade, making it clearer which engines are unavailable for the selected module

## Files changed

 | File | Change |
 |---|---|
 | `src/content/models/nemotron-3-nano-omni.md` | Ollama engine entry in frontmatter + "Running with Ollama" body section |
 | `src/data/benchmarks.json` | Ollama benchmark data + OOM markers for Orin NX/Nano |
 | `src/components/ModelServeSection.astro` | Module tab disabled logic: use union of all engines instead of default engine only |
 | `src/components/matrix/matrixTabStyles.ts` | Disabled engine button: `bg-nvidia-gray-100` fill replaces `opacity-40` |
 | `src/components/ModelBenchmarkSection.astro` | Ollama color token (`#2E2E2E`) + column label dimming when no data |

## Screenshots

<img width="1443" height="608" alt="image" src="https://github.com/user-attachments/assets/01734a47-56c4-4fea-b11f-3f2597fa00ed" />
<img width="1451" height="622" alt="image" src="https://github.com/user-attachments/assets/99a72801-3a4a-4f65-adfc-9889a7fa1af2" />
