### PR TITLE
feat(research): add Emeritus contributors section for past members

### DIFF
--- a/src/content/pages/research.md
+++ b/src/content/pages/research.md
@@ -384,4 +384,4 @@ Our meeting recordings and resources are available for review and reference.
 
 ## Core Contributors
 
-Our research group brings together experts from academia, industry, and the open-source community who are passionate about advancing edge AI and robotics. Below are sustaining members who participate in the research forum and related activities. People who are no longer active in the group but made foundational contributions—including widely used tools such as jetson-containers—are listed separately as **emeritus contributors** at the end of this page.
+Our research group brings together experts from academia, industry, and the open-source community who are passionate about advancing edge AI and robotics. Below are sustaining members who participate in the research forum and related activities. People who are no longer active in the group but made foundational contributions — including widely used tools such as [jetson-containers](https://github.com/dusty-nv/jetson-containers) — are listed separately as **emeritus contributors** at the end of this page.

--- a/src/content/pages/research.md
+++ b/src/content/pages/research.md
@@ -58,14 +58,6 @@ past_meetings:
       - "Review of OpenVLA results (Dustin Franklin)"
       - "Oculus Interface for Jetson (Al Costa)"
 team_members:
-  - name: "Dustin Franklin"
-    role: "Principal Engineer"
-    org: ""
-    location: "Pittsburgh, PA"
-    image: "/images/research/Dustin_Franklin.jpg"
-    linkedin: "https://www.linkedin.com/in/dustin-franklin-b3aaa173/"
-    github: "https://github.com/dusty-nv"
-    expertise: ["jetson-inference", "jetson-containers"]
   - name: "Nurgaliyev Shakhizat"
     role: "Researcher"
     org: "Institute of Smart Systems and AI"
@@ -327,6 +319,15 @@ team_members:
     image: "/images/research/Ori_Nachum.jpg"
     linkedin: ""
     expertise: ["AI", "Innovation"]
+emeritus_members:
+  - name: "Dustin Franklin"
+    role: "Principal Engineer"
+    org: "Formerly NVIDIA"
+    location: "Pittsburgh, PA"
+    image: "/images/research/Dustin_Franklin.jpg"
+    linkedin: "https://www.linkedin.com/in/dustin-franklin-b3aaa173/"
+    github: "https://github.com/dusty-nv"
+    expertise: ["jetson-inference", "jetson-containers"]
 ---
 
 The Jetson AI Lab Research Group is a global collective for advancing open-source Edge ML, open to anyone to join and collaborate with others from the community and leverage each other's work. Our goal is using advanced AI for good in real-world applications in accessible and responsible ways.
@@ -383,4 +384,4 @@ Our meeting recordings and resources are available for review and reference.
 
 ## Core Contributors
 
-Our research group brings together experts from academia, industry, and the open-source community who are passionate about advancing edge AI and robotics. Below are some of our sustaining members who have been actively contributing to generative AI in edge computing.
+Our research group brings together experts from academia, industry, and the open-source community who are passionate about advancing edge AI and robotics. Below are sustaining members who participate in the research forum and related activities. People who are no longer active in the group but made foundational contributions—including widely used tools such as jetson-containers—are listed separately as **emeritus contributors** at the end of this page.

--- a/src/layouts/ResearchLayout.astro
+++ b/src/layouts/ResearchLayout.astro
@@ -20,7 +20,8 @@ const {
   recordings_url,
   research_topics,
   past_meetings,
-  team_members 
+  team_members,
+  emeritus_members,
 } = research.data;
 ---
 
@@ -190,16 +191,17 @@ const {
   )}
 
   <!-- Team Members -->
-  {team_members && team_members.length > 0 && (
+  {((team_members && team_members.length > 0) || (emeritus_members && emeritus_members.length > 0)) && (
     <section class="py-20 bg-slate-50">
       <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div class="text-center mb-12">
           <h2 class="text-3xl font-bold text-slate-900 mb-4">Core Contributors</h2>
           <p class="text-lg text-slate-600 max-w-2xl mx-auto">
-            Our research group brings together experts from academia, industry, and the open-source community who are passionate about advancing edge AI and robotics.
+            Our research group brings together experts from academia, industry, and the open-source community who are passionate about advancing edge AI and robotics. Listed here are members with ongoing participation; foundational contributors who are no longer active in the forum appear as emeritus below.
           </p>
         </div>
         
+        {team_members && team_members.length > 0 && (
         <div class="grid sm:grid-cols-2 lg:grid-cols-4 gap-6">
           {team_members.map(member => (
             <div class="bg-white rounded-xl p-6 shadow-sm border border-slate-200 hover:shadow-md transition-shadow text-center">
@@ -232,6 +234,51 @@ const {
             </div>
           ))}
         </div>
+        )}
+
+        {emeritus_members && emeritus_members.length > 0 && (
+          <div class="mt-16 pt-12 border-t border-slate-200">
+            <div class="text-center mb-10">
+              <h2 class="text-2xl font-bold text-slate-900 mb-3">Emeritus contributors</h2>
+              <p class="text-base text-slate-600 max-w-2xl mx-auto">
+                These members helped establish the research group and the broader Jetson generative-AI ecosystem. Affiliations and links reflect their contributions during active participation; community projects such as jetson-containers remain widely used.
+              </p>
+            </div>
+            <div class="grid sm:grid-cols-2 lg:grid-cols-4 gap-6">
+              {emeritus_members.map(member => (
+                <div class="bg-white rounded-xl p-6 shadow-sm border border-slate-200/80 hover:shadow-md transition-shadow text-center">
+                  <img 
+                    src={member.image} 
+                    alt={member.name}
+                    class="w-24 h-24 rounded-full mx-auto mb-4 object-cover ring-2 ring-slate-200"
+                    loading="lazy"
+                  />
+                  <h3 class="font-bold text-slate-900">{member.name}</h3>
+                  <p class="text-xs font-semibold uppercase tracking-wide text-slate-500 mb-1">Emeritus</p>
+                  <p class="text-sm text-nvidia-green font-medium">{member.org}</p>
+                  <p class="text-xs text-slate-500 mb-3">{member.role} | {member.location}</p>
+                  <div class="flex justify-center gap-2 mb-3">
+                    {member.linkedin && (
+                      <a href={member.linkedin} target="_blank" rel="noopener" class="p-2 bg-slate-100 rounded-full hover:bg-nvidia-green/10 transition-colors">
+                        <svg class="w-4 h-4 text-slate-600" fill="currentColor" viewBox="0 0 24 24"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg>
+                      </a>
+                    )}
+                    {member.github && (
+                      <a href={member.github} target="_blank" rel="noopener" class="p-2 bg-slate-100 rounded-full hover:bg-nvidia-green/10 transition-colors">
+                        <svg class="w-4 h-4 text-slate-600" fill="currentColor" viewBox="0 0 24 24"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
+                      </a>
+                    )}
+                  </div>
+                  <div class="flex flex-wrap justify-center gap-1">
+                    {member.expertise.slice(0, 2).map(skill => (
+                      <span class="text-xs bg-slate-100 text-slate-600 px-2 py-1 rounded-full">{skill}</span>
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
       </div>
     </section>
   )}

--- a/src/layouts/ResearchLayout.astro
+++ b/src/layouts/ResearchLayout.astro
@@ -241,7 +241,7 @@ const {
             <div class="text-center mb-10">
               <h2 class="text-2xl font-bold text-slate-900 mb-3">Emeritus contributors</h2>
               <p class="text-base text-slate-600 max-w-2xl mx-auto">
-                These members helped establish the research group and the broader Jetson generative-AI ecosystem. Affiliations and links reflect their contributions during active participation; community projects such as jetson-containers remain widely used.
+                These members helped establish the research group and the broader Jetson generative-AI ecosystem. Affiliations and links reflect their contributions during active participation; community projects such as <a href="https://github.com/dusty-nv/jetson-containers" class="text-nvidia-green hover:underline font-medium">jetson-containers</a> remain widely used.
               </p>
             </div>
             <div class="grid sm:grid-cols-2 lg:grid-cols-4 gap-6">


### PR DESCRIPTION
## Summary

New emeritus_members in research.md, layout subsection under Core Contributors, Dusty moved to emeritus with “Formerly NVIDIA,” ties to an ask to keep past contributors visible without implying active participation.

## Screenshot

<img width="1837" height="1153" alt="image" src="https://github.com/user-attachments/assets/68692ea8-0de9-4e37-b316-7c8e21ff1cb0" />
